### PR TITLE
Move vite to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "eslint-plugin-markdown": "^2.2.0",
     "rollup": "^2.77.0",
     "rollup-plugin-esbuild": "^4.9.1",
-    "typescript": "^4.7.4"
-  },
-  "dependencies": {
+    "typescript": "^4.7.4",
     "vite": "^3.0.2"
+  },
+  "peerDependencies": {
+    "vite": "*"
   }
 }


### PR DESCRIPTION
Move vite to peerDependencies so the plugin can work with both 3 and 4 version of vite.